### PR TITLE
feat: Enable module to create and store user credentials in 'supabase_users_field_table'

### DIFF
--- a/src/SupabaseService.php
+++ b/src/SupabaseService.php
@@ -3,14 +3,12 @@
 namespace Drupal\supabase_authentication;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
 use PHPSupabase\Service;
+use Psr\Log\LoggerInterface;
 
 /**
- * Contains \Drupal\supabase_authentication\SupabaseService.
- */
-
-/**
- * Service class for integrating with Supabase.
+ * Provides methods to interact with the Supabase authentication service.
  */
 class SupabaseService {
 
@@ -29,13 +27,33 @@ class SupabaseService {
   protected $supabaseService;
 
   /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * SupabaseService constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(ConfigFactoryInterface $config_factory, Connection $database, LoggerInterface $logger) {
     $this->configFactory = $config_factory;
+    $this->database = $database;
+    $this->logger = $logger;
     $config = $this->configFactory->get('supabase_authentication.config_form');
 
     $apiKey = $config->get('api_key');
@@ -86,6 +104,48 @@ class SupabaseService {
     }
     catch (\Exception $e) {
       return $auth->getError();
+    }
+  }
+
+  /**
+   * Stores user credentials in the custom table.
+   *
+   * @param string $email
+   *   The email of the user.
+   * @param string $password
+   *   The password of the user.
+   */
+  public function storeUserCredentials($email, $password) {
+    $this->database->insert('supabase_users_field_table')
+      ->fields([
+        'email' => $email,
+        'password' => $password,
+        'created' => \Drupal::time()->getRequestTime(),
+      ])
+      ->execute();
+  }
+
+  /**
+   * Logs a message.
+   *
+   * @param string $level
+   *   The log level (e.g., 'notice', 'error').
+   * @param string $message
+   *   The log message.
+   * @param array $context
+   *   Additional context for the log message.
+   */
+  public function log($level, $message, array $context = []) {
+    $this->logger->$level($message, $context);
+  }
+
+  /**
+   * Drops the custom table.
+   */
+  public function dropTable() {
+    $schema = $this->database->schema();
+    if ($schema->tableExists('supabase_users_field_table')) {
+      $schema->dropTable('supabase_users_field_table');
     }
   }
 

--- a/supabase_authentication.install
+++ b/supabase_authentication.install
@@ -37,3 +37,36 @@ function supabase_authentication_install() {
     $form_display->save();
   }
 }
+
+/**
+ * Implements hook_schema().
+ */
+function supabase_authentication_schema() {
+  $schema['supabase_users_field_table'] = [
+    'description' => 'Stores Supabase user email and password.',
+    'fields' => [
+      'uid' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'email' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'password' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => REQUEST_TIME,
+      ],
+    ],
+    'primary key' => ['uid'],
+  ];
+
+  return $schema;
+}

--- a/supabase_authentication.module
+++ b/supabase_authentication.module
@@ -23,43 +23,40 @@ function supabase_authentication_help($route_name, RouteMatchInterface $route_ma
  */
 function supabase_authentication_user_insert(User $user) {
   $supabase_service = \Drupal::service('supabase_authentication.supabase');
-  $password_generator = \Drupal::service('password_generator');
   $email = $user->getEmail();
 
-  // Generate a random password.
-  $password = $password_generator->generate();
+  // Retrieve the password using the getPassword method.
+  $password = $user->getPassword();
 
   // Create user in Supabase.
   $supabase_response = $supabase_service->createUser($email, $password);
   if (isset($supabase_response->id)) {
-    \Drupal::logger('supabase_authentication')->notice(
-      'User @username created in Supabase.',
-      ['@username' => $email]
-    );
+    $supabase_service->log('notice', 'User @username created in Supabase.', [
+      '@username' => $email,
+    ]);
+
+    // Insert the user's email and password into the custom table using the
+    // service method.
+    $supabase_service->storeUserCredentials($email, $password);
   }
   else {
-    \Drupal::logger('supabase_authentication')->error(
-      'Failed to create user @username in Supabase: @error', [
-        '@username' => $email,
-        '@error' => print_r($supabase_response, TRUE),
-      ]
-    );
+    $supabase_service->log('error', 'Failed to create user @username in Supabase: @error', [
+      '@username' => $email,
+      '@error' => print_r($supabase_response, TRUE),
+    ]);
   }
 
   // Sign in the user to get the access token (optional).
   $supabase_auth = $supabase_service->signInUser($email, $password);
   if (isset($supabase_auth->access_token)) {
-    \Drupal::logger('supabase_authentication')->notice(
-      'User @username authenticated with Supabase.',
-      ['@username' => $email]
-    );
+    $supabase_service->log('notice', 'User @username authenticated with Supabase.', [
+      '@username' => $email,
+    ]);
   }
   else {
-    \Drupal::logger('supabase_authentication')->error(
-      'Failed to authenticate user @username with Supabase: @error', [
-        '@username' => $email,
-        '@error' => print_r($supabase_auth, TRUE),
-      ]
-    );
+    $supabase_service->log('error', 'Failed to authenticate user @username with Supabase: @error', [
+      '@username' => $email,
+      '@error' => print_r($supabase_auth, TRUE),
+    ]);
   }
 }

--- a/supabase_authentication.services.yml
+++ b/supabase_authentication.services.yml
@@ -1,4 +1,9 @@
 services:
   supabase_authentication.supabase:
     class: 'Drupal\supabase_authentication\SupabaseService'
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@database', '@logger.channel.supabase_authentication']
+
+  logger.channel.supabase_authentication:
+    class: Drupal\Core\Logger\LoggerChannel
+    factory: ['@logger.factory', 'get']
+    arguments: ['supabase_authentication']


### PR DESCRIPTION
### Overview

This pull request enables the module to create and store user credentials in the `supabase_users_field_table` during module installation. This enhancement ensures that user data is correctly handled and stored within the Drupal environment.

---

### Before

- The module did not store user credentials.
- There was no table `supabase_users_field_table` created during the module installation.

---

### After

- The module now creates the `supabase_users_field_table` during installation.
- User credentials can be stored in the `supabase_users_field_table`.
- No errors related to missing tables.

**Screenshots:**

![image](https://github.com/md61421/supabase_authentication/assets/51356561/c1b271e0-fc7b-46c5-b911-0568201ea07a)
*Screenshot of the `supabase_users_field_table` Structure.*

---

### Technical Details

- Implemented `hook_schema()` to define the schema for `supabase_users_field_table`.
  ```php
  function supabase_authentication_schema() {
    $schema['supabase_users_field_table'] = [
      'description' => 'Stores Supabase user email and password.',
      'fields' => [
        'uid' => [
          'type' => 'serial',
          'not null' => TRUE,
        ],
        'email' => [
          'type' => 'varchar',
          'length' => 255,
          'not null' => TRUE,
        ],
        'password' => [
          'type' => 'varchar',
          'length' => 255,
          'not null' => TRUE,
        ],
      ],
      'primary key' => ['uid'],
    ];

    return $schema;
  }
  ```

- Recommended steps to uninstall and reinstall the module to ensure the table creation is executed:
  1. Uninstall the module via **Extend** > **Uninstall**.
  2. Reinstall the module via **Extend**.

This pull request introduces the ability for the module to handle user credentials effectively, ensuring data integrity and proper storage within the Drupal environment.